### PR TITLE
Update 1 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.PlatformClient.nuspec
+++ b/MakoIoT.Device.PlatformClient.nuspec
@@ -29,7 +29,7 @@
       <dependency id="nanoFramework.System.IO.FileSystem" version="1.1.23" />
       <dependency id="nanoFramework.System.IO.Streams" version="1.1.38" />
       <dependency id="nanoFramework.System.Net" version="1.10.62" />
-      <dependency id="nanoFramework.System.Net.Http" version="1.5.104" />
+      <dependency id="nanoFramework.System.Net.Http" version="1.5.106" />
       <dependency id="nanoFramework.System.Text" version="1.2.37" />
       <dependency id="nanoFramework.System.Threading" version="1.1.19" />
     </dependencies>

--- a/Tests/SoftwareTests/MakoIoT.Device.PlatformClient.Test/MakoIoT.Device.PlatformClient.Test.nfproj
+++ b/Tests/SoftwareTests/MakoIoT.Device.PlatformClient.Test/MakoIoT.Device.PlatformClient.Test.nfproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <NanoFrameworkProjectSystemPath>$(MSBuildExtensionsPath)\nanoFramework\v1.0\</NanoFrameworkProjectSystemPath>

--- a/src/MakoIoT.Device.PlatformClient/MakoIoT.Device.PlatformClient.nfproj
+++ b/src/MakoIoT.Device.PlatformClient/MakoIoT.Device.PlatformClient.nfproj
@@ -67,8 +67,9 @@
     <Reference Include="System.Net">
       <HintPath>..\..\packages\nanoFramework.System.Net.1.10.62\lib\System.Net.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http">
-      <HintPath>..\..\packages\nanoFramework.System.Net.Http.1.5.104\lib\System.Net.Http.dll</HintPath>
+    <Reference Include="System.Net.Http, Version=1.5.106.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Net.Http.1.5.106\lib\System.Net.Http.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Threading">
       <HintPath>..\..\packages\nanoFramework.System.Threading.1.1.19\lib\System.Threading.dll</HintPath>

--- a/src/MakoIoT.Device.PlatformClient/packages.config
+++ b/src/MakoIoT.Device.PlatformClient/packages.config
@@ -12,7 +12,7 @@
   <package id="nanoFramework.System.IO.FileSystem" version="1.1.23" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.IO.Streams" version="1.1.38" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Net" version="1.10.62" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net.Http" version="1.5.104" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net.Http" version="1.5.106" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Text" version="1.2.37" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Threading" version="1.1.19" targetFramework="netnano1.0" />
   <package id="Nerdbank.GitVersioning" version="3.6.133" targetFramework="netnano1.0" developmentDependency="true" />


### PR DESCRIPTION
Bumps nanoFramework.System.Net.Http from 1.5.104 to 1.5.106</br>
[version update]

### :warning: This is an automated update. :warning:
