### PR TITLE
Update 2 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.PlatformClient.nuspec
+++ b/MakoIoT.Device.PlatformClient.nuspec
@@ -19,8 +19,8 @@
     <dependencies>
       <dependency id="MakoIoT.Device.Platform.Interface" version="1.0.1.28390" />
       <dependency id="MakoIoT.Device.Services.FileStorage" version="1.0.30.57507" />
-      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.36.21434" />
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.38.18612" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.14.20" />
       <dependency id="nanoFramework.DependencyInjection" version="1.1.1" />
       <dependency id="nanoFramework.Json" version="2.2.101" />
       <dependency id="nanoFramework.Logging" version="1.1.63" />

--- a/Tests/SoftwareTests/MakoIoT.Device.PlatformClient.Test/MakoIoT.Device.PlatformClient.Test.nfproj
+++ b/Tests/SoftwareTests/MakoIoT.Device.PlatformClient.Test/MakoIoT.Device.PlatformClient.Test.nfproj
@@ -37,11 +37,13 @@
     <Reference Include="MakoIoT.Device.Services.FileStorage">
       <HintPath>..\..\..\packages\MakoIoT.Device.Services.FileStorage.1.0.30.57507\lib\MakoIoT.Device.Services.FileStorage.dll</HintPath>
     </Reference>
-    <Reference Include="MakoIoT.Device.Services.Interface">
-      <HintPath>..\..\..\packages\MakoIoT.Device.Services.Interface.1.0.36.21434\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+    <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\packages\MakoIoT.Device.Services.Interface.1.0.38.18612\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="mscorlib">
-      <HintPath>..\..\..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.14.20.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\..\packages\nanoFramework.CoreLibrary.1.14.20\lib\mscorlib.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.DependencyInjection, Version=1.1.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\..\packages\nanoFramework.DependencyInjection.1.1.1\lib\nanoFramework.DependencyInjection.dll</HintPath>

--- a/Tests/SoftwareTests/MakoIoT.Device.PlatformClient.Test/packages.config
+++ b/Tests/SoftwareTests/MakoIoT.Device.PlatformClient.Test/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MakoIoT.Device.Services.FileStorage" version="1.0.30.57507" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Interface" version="1.0.36.21434" targetFramework="netnano1.0" />
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Interface" version="1.0.38.18612" targetFramework="netnano1.0" />
+  <package id="nanoFramework.CoreLibrary" version="1.14.20" targetFramework="netnano1.0" />
   <package id="nanoFramework.DependencyInjection" version="1.1.1" targetFramework="netnano1.0" />
   <package id="nanoFramework.Logging" version="1.1.63" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Events" version="1.11.6" targetFramework="netnano1.0" />

--- a/src/MakoIoT.Device.PlatformClient/MakoIoT.Device.PlatformClient.nfproj
+++ b/src/MakoIoT.Device.PlatformClient/MakoIoT.Device.PlatformClient.nfproj
@@ -34,11 +34,13 @@
     <Reference Include="MakoIoT.Device.Services.FileStorage">
       <HintPath>..\..\packages\MakoIoT.Device.Services.FileStorage.1.0.30.57507\lib\MakoIoT.Device.Services.FileStorage.dll</HintPath>
     </Reference>
-    <Reference Include="MakoIoT.Device.Services.Interface">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.36.21434\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+    <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.38.18612\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="mscorlib">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.14.20.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.14.20\lib\mscorlib.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.DependencyInjection, Version=1.1.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.1\lib\nanoFramework.DependencyInjection.dll</HintPath>

--- a/src/MakoIoT.Device.PlatformClient/packages.config
+++ b/src/MakoIoT.Device.PlatformClient/packages.config
@@ -2,8 +2,8 @@
 <packages>
   <package id="MakoIoT.Device.Platform.Interface" version="1.0.1.28390" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.FileStorage" version="1.0.30.57507" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Interface" version="1.0.36.21434" targetFramework="netnano1.0" />
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Interface" version="1.0.38.18612" targetFramework="netnano1.0" />
+  <package id="nanoFramework.CoreLibrary" version="1.14.20" targetFramework="netnano1.0" />
   <package id="nanoFramework.DependencyInjection" version="1.1.1" targetFramework="netnano1.0" />
   <package id="nanoFramework.Json" version="2.2.101" targetFramework="netnano1.0" />
   <package id="nanoFramework.Logging" version="1.1.63" targetFramework="netnano1.0" />


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.Interface from 1.0.36.21434 to 1.0.38.18612</br>Bumps nanoFramework.CoreLibrary from 1.14.2 to 1.14.20</br>
[version update]

### :warning: This is an automated update. :warning:
