### PR TITLE
Update 4 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.PlatformClient.nuspec
+++ b/MakoIoT.Device.PlatformClient.nuspec
@@ -17,15 +17,15 @@
     <description>MAKO-IoT PLatform device client library</description>
     <tags>nanoFramework C# csharp netmf netnf mako-iot platform device</tags>
     <dependencies>
-      <dependency id="MakoIoT.Device.Platform.Interface" version="1.0.9.33126" />
-      <dependency id="MakoIoT.Device.Services.FileStorage" version="1.0.49.32114" />
+      <dependency id="MakoIoT.Device.Platform.Interface" version="1.0.10.15735" />
+      <dependency id="MakoIoT.Device.Services.FileStorage" version="1.0.51.18737" />
       <dependency id="MakoIoT.Device.Services.Interface" version="1.0.46.2905" />
       <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
       <dependency id="nanoFramework.DependencyInjection" version="1.1.3" />
       <dependency id="nanoFramework.Json" version="2.2.117" />
       <dependency id="nanoFramework.Runtime.Events" version="1.11.15" />
       <dependency id="nanoFramework.System.Collections" version="1.5.31" />
-      <dependency id="nanoFramework.System.IO.FileSystem" version="1.1.36" />
+      <dependency id="nanoFramework.System.IO.FileSystem" version="1.1.41" />
       <dependency id="nanoFramework.System.IO.Streams" version="1.1.59" />
       <dependency id="nanoFramework.System.Net" version="1.10.77" />
       <dependency id="nanoFramework.System.Net.Http" version="1.5.134" />

--- a/Tests/SoftwareTests/MakoIoT.Device.PlatformClient.Test/MakoIoT.Device.PlatformClient.Test.nfproj
+++ b/Tests/SoftwareTests/MakoIoT.Device.PlatformClient.Test/MakoIoT.Device.PlatformClient.Test.nfproj
@@ -35,7 +35,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="MakoIoT.Device.Services.FileStorage, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\..\packages\MakoIoT.Device.Services.FileStorage.1.0.49.32114\lib\MakoIoT.Device.Services.FileStorage.dll</HintPath>
+      <HintPath>..\..\..\packages\MakoIoT.Device.Services.FileStorage.1.0.51.18737\lib\MakoIoT.Device.Services.FileStorage.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
@@ -50,8 +50,8 @@
       <HintPath>..\..\..\packages\nanoFramework.DependencyInjection.1.1.3\lib\nanoFramework.DependencyInjection.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.Logging, Version=1.1.92.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.Logging.1.1.92\lib\nanoFramework.Logging.dll</HintPath>
+    <Reference Include="nanoFramework.Logging, Version=1.1.94.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\..\packages\nanoFramework.Logging.1.1.94\lib\nanoFramework.Logging.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Events, Version=1.11.15.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
@@ -78,8 +78,8 @@
       <HintPath>..\..\..\packages\nanoFramework.TestFramework.2.1.94\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.IO.FileSystem, Version=1.1.36.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.System.IO.FileSystem.1.1.36\lib\System.IO.FileSystem.dll</HintPath>
+    <Reference Include="System.IO.FileSystem, Version=1.1.41.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\..\packages\nanoFramework.System.IO.FileSystem.1.1.41\lib\System.IO.FileSystem.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.IO.Streams, Version=1.1.59.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">

--- a/Tests/SoftwareTests/MakoIoT.Device.PlatformClient.Test/packages.config
+++ b/Tests/SoftwareTests/MakoIoT.Device.PlatformClient.Test/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MakoIoT.Device.Services.FileStorage" version="1.0.49.32114" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.FileStorage" version="1.0.51.18737" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Interface" version="1.0.46.2905" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnano1.0" />
   <package id="nanoFramework.DependencyInjection" version="1.1.3" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Logging" version="1.1.92" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Logging" version="1.1.94" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Events" version="1.11.15" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Collections" version="1.5.31" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.IO.FileSystem" version="1.1.36" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.IO.FileSystem" version="1.1.41" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.IO.Streams" version="1.1.59" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Runtime" version="1.0.6" />
   <package id="nanoFramework.System.Text" version="1.2.54" targetFramework="netnano1.0" />

--- a/src/MakoIoT.Device.PlatformClient/MakoIoT.Device.PlatformClient.nfproj
+++ b/src/MakoIoT.Device.PlatformClient/MakoIoT.Device.PlatformClient.nfproj
@@ -29,11 +29,11 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="MakoIoT.Device.Platform.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Platform.Interface.1.0.9.33126\lib\MakoIoT.Device.Platform.Interface.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Platform.Interface.1.0.10.15735\lib\MakoIoT.Device.Platform.Interface.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.FileStorage, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.FileStorage.1.0.49.32114\lib\MakoIoT.Device.Services.FileStorage.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.FileStorage.1.0.51.18737\lib\MakoIoT.Device.Services.FileStorage.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
@@ -52,8 +52,8 @@
       <HintPath>..\..\packages\nanoFramework.Json.2.2.117\lib\nanoFramework.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.Logging, Version=1.1.92.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Logging.1.1.92\lib\nanoFramework.Logging.dll</HintPath>
+    <Reference Include="nanoFramework.Logging, Version=1.1.94.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Logging.1.1.94\lib\nanoFramework.Logging.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Events, Version=1.11.15.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
@@ -72,8 +72,8 @@
       <HintPath>..\..\packages\nanoFramework.System.Text.1.2.54\lib\nanoFramework.System.Text.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.IO.FileSystem, Version=1.1.36.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.IO.FileSystem.1.1.36\lib\System.IO.FileSystem.dll</HintPath>
+    <Reference Include="System.IO.FileSystem, Version=1.1.41.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.IO.FileSystem.1.1.41\lib\System.IO.FileSystem.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.IO.Streams, Version=1.1.59.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">

--- a/src/MakoIoT.Device.PlatformClient/packages.config
+++ b/src/MakoIoT.Device.PlatformClient/packages.config
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MakoIoT.Device.Platform.Interface" version="1.0.9.33126" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.FileStorage" version="1.0.49.32114" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Platform.Interface" version="1.0.10.15735" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.FileStorage" version="1.0.51.18737" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Interface" version="1.0.46.2905" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnano1.0" />
   <package id="nanoFramework.DependencyInjection" version="1.1.3" targetFramework="netnano1.0" />
   <package id="nanoFramework.Json" version="2.2.117" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Logging" version="1.1.92" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Logging" version="1.1.94" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Events" version="1.11.15" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Collections" version="1.5.31" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.IO.FileSystem" version="1.1.36" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.IO.FileSystem" version="1.1.41" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.IO.Streams" version="1.1.59" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Net" version="1.10.77" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Net.Http" version="1.5.134" targetFramework="netnano1.0" />


### PR DESCRIPTION
Bumps MakoIoT.Device.Platform.Interface from 1.0.9.33126 to 1.0.10.15735</br>Bumps MakoIoT.Device.Services.FileStorage from 1.0.49.32114 to 1.0.51.18737</br>Bumps nanoFramework.Logging from 1.1.92 to 1.1.94</br>Bumps nanoFramework.System.IO.FileSystem from 1.1.36 to 1.1.41</br>
[version update]

### :warning: This is an automated update. :warning:
