### PR TITLE
Update 3 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.PlatformClient.nuspec
+++ b/MakoIoT.Device.PlatformClient.nuspec
@@ -27,8 +27,8 @@
       <dependency id="nanoFramework.System.Collections" version="1.5.31" />
       <dependency id="nanoFramework.System.IO.FileSystem" version="1.1.45" />
       <dependency id="nanoFramework.System.IO.Streams" version="1.1.59" />
-      <dependency id="nanoFramework.System.Net" version="1.10.77" />
-      <dependency id="nanoFramework.System.Net.Http" version="1.5.136" />
+      <dependency id="nanoFramework.System.Net" version="1.10.79" />
+      <dependency id="nanoFramework.System.Net.Http" version="1.5.138" />
       <dependency id="nanoFramework.System.Text" version="1.2.54" />
       <dependency id="nanoFramework.System.Threading" version="1.1.32" />
     </dependencies>

--- a/Tests/SoftwareTests/MakoIoT.Device.PlatformClient.Test/MakoIoT.Device.PlatformClient.Test.nfproj
+++ b/Tests/SoftwareTests/MakoIoT.Device.PlatformClient.Test/MakoIoT.Device.PlatformClient.Test.nfproj
@@ -50,8 +50,8 @@
       <HintPath>..\..\..\packages\nanoFramework.DependencyInjection.1.1.3\lib\nanoFramework.DependencyInjection.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.Logging, Version=1.1.96.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.Logging.1.1.96\lib\nanoFramework.Logging.dll</HintPath>
+    <Reference Include="nanoFramework.Logging, Version=1.1.98.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\..\packages\nanoFramework.Logging.1.1.98\lib\nanoFramework.Logging.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Events, Version=1.11.18.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">

--- a/Tests/SoftwareTests/MakoIoT.Device.PlatformClient.Test/packages.config
+++ b/Tests/SoftwareTests/MakoIoT.Device.PlatformClient.Test/packages.config
@@ -4,7 +4,7 @@
   <package id="MakoIoT.Device.Services.Interface" version="1.0.46.2905" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnano1.0" />
   <package id="nanoFramework.DependencyInjection" version="1.1.3" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Logging" version="1.1.96" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Logging" version="1.1.98" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Events" version="1.11.18" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Collections" version="1.5.31" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.IO.FileSystem" version="1.1.45" targetFramework="netnano1.0" />

--- a/src/MakoIoT.Device.PlatformClient/MakoIoT.Device.PlatformClient.nfproj
+++ b/src/MakoIoT.Device.PlatformClient/MakoIoT.Device.PlatformClient.nfproj
@@ -52,8 +52,8 @@
       <HintPath>..\..\packages\nanoFramework.Json.2.2.117\lib\nanoFramework.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.Logging, Version=1.1.96.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Logging.1.1.96\lib\nanoFramework.Logging.dll</HintPath>
+    <Reference Include="nanoFramework.Logging, Version=1.1.98.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Logging.1.1.98\lib\nanoFramework.Logging.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Events, Version=1.11.18.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
@@ -80,12 +80,12 @@
       <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.59\lib\System.IO.Streams.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Net, Version=1.10.77.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Net.1.10.77\lib\System.Net.dll</HintPath>
+    <Reference Include="System.Net, Version=1.10.79.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Net.1.10.79\lib\System.Net.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Net.Http, Version=1.5.136.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Net.Http.1.5.136\lib\System.Net.Http.dll</HintPath>
+    <Reference Include="System.Net.Http, Version=1.5.138.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Net.Http.1.5.138\lib\System.Net.Http.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Threading, Version=1.1.32.63105, Culture=neutral, PublicKeyToken=c07d481e9758c731">

--- a/src/MakoIoT.Device.PlatformClient/packages.config
+++ b/src/MakoIoT.Device.PlatformClient/packages.config
@@ -6,13 +6,13 @@
   <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnano1.0" />
   <package id="nanoFramework.DependencyInjection" version="1.1.3" targetFramework="netnano1.0" />
   <package id="nanoFramework.Json" version="2.2.117" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Logging" version="1.1.96" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Logging" version="1.1.98" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Events" version="1.11.18" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Collections" version="1.5.31" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.IO.FileSystem" version="1.1.45" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.IO.Streams" version="1.1.59" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net" version="1.10.77" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net.Http" version="1.5.136" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net" version="1.10.79" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net.Http" version="1.5.138" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Runtime" version="1.0.6" />
   <package id="nanoFramework.System.Text" version="1.2.54" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Threading" version="1.1.32" targetFramework="netnano1.0" />


### PR DESCRIPTION
Bumps nanoFramework.Logging from 1.1.96 to 1.1.98</br>Bumps nanoFramework.System.Net from 1.10.77 to 1.10.79</br>Bumps nanoFramework.System.Net.Http from 1.5.136 to 1.5.138</br>
[version update]

### :warning: This is an automated update. :warning:
