### PR TITLE
Update 4 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.PlatformClient.nuspec
+++ b/MakoIoT.Device.PlatformClient.nuspec
@@ -18,7 +18,7 @@
     <tags>nanoFramework C# csharp netmf netnf mako-iot platform device</tags>
     <dependencies>
       <dependency id="MakoIoT.Device.Platform.Interface" version="1.0.12.12799" />
-      <dependency id="MakoIoT.Device.Services.FileStorage" version="1.0.57.49182" />
+      <dependency id="MakoIoT.Device.Services.FileStorage" version="1.0.58.24818" />
       <dependency id="MakoIoT.Device.Services.Interface" version="1.0.46.2905" />
       <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
       <dependency id="nanoFramework.DependencyInjection" version="1.1.3" />

--- a/Tests/SoftwareTests/MakoIoT.Device.PlatformClient.Test/MakoIoT.Device.PlatformClient.Test.nfproj
+++ b/Tests/SoftwareTests/MakoIoT.Device.PlatformClient.Test/MakoIoT.Device.PlatformClient.Test.nfproj
@@ -35,7 +35,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="MakoIoT.Device.Services.FileStorage, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\..\packages\MakoIoT.Device.Services.FileStorage.1.0.57.49182\lib\MakoIoT.Device.Services.FileStorage.dll</HintPath>
+      <HintPath>..\..\..\packages\MakoIoT.Device.Services.FileStorage.1.0.59.27693\lib\MakoIoT.Device.Services.FileStorage.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
@@ -70,12 +70,12 @@
       <HintPath>..\..\..\packages\nanoFramework.System.Text.1.2.54\lib\nanoFramework.System.Text.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.TestFramework, Version=2.1.104.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.TestFramework.2.1.104\lib\nanoFramework.TestFramework.dll</HintPath>
+    <Reference Include="nanoFramework.TestFramework, Version=2.1.107.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\..\packages\nanoFramework.TestFramework.2.1.107\lib\nanoFramework.TestFramework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.UnitTestLauncher, Version=0.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.TestFramework.2.1.104\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
+      <HintPath>..\..\..\packages\nanoFramework.TestFramework.2.1.107\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.IO.FileSystem, Version=1.1.47.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">

--- a/Tests/SoftwareTests/MakoIoT.Device.PlatformClient.Test/packages.config
+++ b/Tests/SoftwareTests/MakoIoT.Device.PlatformClient.Test/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MakoIoT.Device.Services.FileStorage" version="1.0.57.49182" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.FileStorage" version="1.0.59.27693" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Interface" version="1.0.46.2905" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnano1.0" />
   <package id="nanoFramework.DependencyInjection" version="1.1.3" targetFramework="netnano1.0" />
@@ -11,5 +11,5 @@
   <package id="nanoFramework.System.IO.Streams" version="1.1.59" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Runtime" version="1.0.27" />
   <package id="nanoFramework.System.Text" version="1.2.54" targetFramework="netnano1.0" />
-  <package id="nanoFramework.TestFramework" version="2.1.104" targetFramework="netnano1.0" developmentDependency="true" />
+  <package id="nanoFramework.TestFramework" version="2.1.107" targetFramework="netnano1.0" developmentDependency="true" />
 </packages>

--- a/src/MakoIoT.Device.PlatformClient/MakoIoT.Device.PlatformClient.nfproj
+++ b/src/MakoIoT.Device.PlatformClient/MakoIoT.Device.PlatformClient.nfproj
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\Nerdbank.GitVersioning.3.6.139\build\Nerdbank.GitVersioning.props" Condition="Exists('..\..\packages\Nerdbank.GitVersioning.3.6.139\build\Nerdbank.GitVersioning.props')" />
   <PropertyGroup Label="Globals">
     <NanoFrameworkProjectSystemPath>$(MSBuildExtensionsPath)\nanoFramework\v1.0\</NanoFrameworkProjectSystemPath>
   </PropertyGroup>
@@ -33,7 +34,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.FileStorage, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.FileStorage.1.0.57.49182\lib\MakoIoT.Device.Services.FileStorage.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.FileStorage.1.0.58.24818\lib\MakoIoT.Device.Services.FileStorage.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
@@ -107,7 +108,8 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\Nerdbank.GitVersioning.3.6.133\build\Nerdbank.GitVersioning.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Nerdbank.GitVersioning.3.6.133\build\Nerdbank.GitVersioning.props'))" />
-    <Error Condition="!Exists('..\..\packages\Nerdbank.GitVersioning.3.6.133\build\Nerdbank.GitVersioning.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Nerdbank.GitVersioning.3.6.133\build\Nerdbank.GitVersioning.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Nerdbank.GitVersioning.3.6.139\build\Nerdbank.GitVersioning.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Nerdbank.GitVersioning.3.6.139\build\Nerdbank.GitVersioning.props'))" />
+    <Error Condition="!Exists('..\..\packages\Nerdbank.GitVersioning.3.6.139\build\Nerdbank.GitVersioning.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Nerdbank.GitVersioning.3.6.139\build\Nerdbank.GitVersioning.targets'))" />
   </Target>
-  <Import Project="..\..\packages\Nerdbank.GitVersioning.3.6.133\build\Nerdbank.GitVersioning.targets" Condition="Exists('..\..\packages\Nerdbank.GitVersioning.3.6.133\build\Nerdbank.GitVersioning.targets')" />
+  <Import Project="..\..\packages\Nerdbank.GitVersioning.3.6.139\build\Nerdbank.GitVersioning.targets" Condition="Exists('..\..\packages\Nerdbank.GitVersioning.3.6.139\build\Nerdbank.GitVersioning.targets')" />
 </Project>

--- a/src/MakoIoT.Device.PlatformClient/packages.config
+++ b/src/MakoIoT.Device.PlatformClient/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MakoIoT.Device.Platform.Interface" version="1.0.12.12799" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.FileStorage" version="1.0.57.49182" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.FileStorage" version="1.0.58.24818" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Interface" version="1.0.46.2905" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnano1.0" />
   <package id="nanoFramework.DependencyInjection" version="1.1.3" targetFramework="netnano1.0" />
@@ -16,5 +16,5 @@
   <package id="nanoFramework.System.Runtime" version="1.0.27" />
   <package id="nanoFramework.System.Text" version="1.2.54" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Threading" version="1.1.32" targetFramework="netnano1.0" />
-  <package id="Nerdbank.GitVersioning" version="3.6.133" targetFramework="netnano1.0" developmentDependency="true" />
+  <package id="Nerdbank.GitVersioning" version="3.6.139" targetFramework="netnano1.0" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.FileStorage from 1.0.57.49182 to 1.0.58.24818</br>Bumps Nerdbank.GitVersioning from 3.6.133 to 3.6.139</br>Bumps MakoIoT.Device.Services.FileStorage from 1.0.57.49182 to 1.0.59.27693</br>Bumps nanoFramework.TestFramework from 2.1.104 to 2.1.107</br>
[version update]

### :warning: This is an automated update. :warning:
