### PR TITLE
Update 1 NuGet dependencies

### DIFF
--- a/Tests/SoftwareTests/MakoIoT.Device.PlatformClient.Test/MakoIoT.Device.PlatformClient.Test.nfproj
+++ b/Tests/SoftwareTests/MakoIoT.Device.PlatformClient.Test/MakoIoT.Device.PlatformClient.Test.nfproj
@@ -61,11 +61,11 @@
     <Reference Include="nanoFramework.System.Text, Version=1.3.42.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\..\packages\nanoFramework.System.Text.1.3.42\lib\nanoFramework.System.Text.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.TestFramework, Version=3.0.75.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.TestFramework.3.0.75\lib\nanoFramework.TestFramework.dll</HintPath>
+    <Reference Include="nanoFramework.TestFramework, Version=3.0.77.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\..\packages\nanoFramework.TestFramework.3.0.77\lib\nanoFramework.TestFramework.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.UnitTestLauncher, Version=0.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.TestFramework.3.0.75\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
+      <HintPath>..\..\..\packages\nanoFramework.TestFramework.3.0.77\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
     </Reference>
     <Reference Include="System.IO.FileSystem, Version=1.1.85.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\..\packages\nanoFramework.System.IO.FileSystem.1.1.85\lib\System.IO.FileSystem.dll</HintPath>

--- a/Tests/SoftwareTests/MakoIoT.Device.PlatformClient.Test/packages.config
+++ b/Tests/SoftwareTests/MakoIoT.Device.PlatformClient.Test/packages.config
@@ -11,5 +11,5 @@
   <package id="nanoFramework.System.IO.Streams" version="1.1.94" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Runtime" version="1.0.28" />
   <package id="nanoFramework.System.Text" version="1.3.42" targetFramework="netnano1.0" />
-  <package id="nanoFramework.TestFramework" version="3.0.75" targetFramework="netnano1.0" developmentDependency="true" />
+  <package id="nanoFramework.TestFramework" version="3.0.77" targetFramework="netnano1.0" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Bumps nanoFramework.TestFramework from 3.0.75 to 3.0.77</br>
[version update]

### :warning: This is an automated update. :warning:
