### PR TITLE
Update 2 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.PlatformClient.nuspec
+++ b/MakoIoT.Device.PlatformClient.nuspec
@@ -17,7 +17,7 @@
     <description>MAKO-IoT PLatform device client library</description>
     <tags>nanoFramework C# csharp netmf netnf mako-iot platform device</tags>
     <dependencies>
-      <dependency id="MakoIoT.Device.Platform.Interface" version="1.0.25.43828" />
+      <dependency id="MakoIoT.Device.Platform.Interface" version="1.0.26.3091" />
       <dependency id="MakoIoT.Device.Services.FileStorage" version="1.1.15.13530" />
       <dependency id="MakoIoT.Device.Services.Interface" version="1.0.55.11594" />
       <dependency id="nanoFramework.CoreLibrary" version="1.17.11" />
@@ -27,7 +27,7 @@
       <dependency id="nanoFramework.System.Collections" version="1.5.67" />
       <dependency id="nanoFramework.System.IO.FileSystem" version="1.1.85" />
       <dependency id="nanoFramework.System.IO.Streams" version="1.1.96" />
-      <dependency id="nanoFramework.System.Net" version="1.11.42" />
+      <dependency id="nanoFramework.System.Net" version="1.11.43" />
       <dependency id="nanoFramework.System.Net.Http" version="1.5.193" />
       <dependency id="nanoFramework.System.Text" version="1.3.42" />
       <dependency id="nanoFramework.System.Threading" version="1.1.52" />

--- a/src/MakoIoT.Device.PlatformClient/MakoIoT.Device.PlatformClient.nfproj
+++ b/src/MakoIoT.Device.PlatformClient/MakoIoT.Device.PlatformClient.nfproj
@@ -30,7 +30,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="MakoIoT.Device.Platform.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Platform.Interface.1.0.25.43828\lib\MakoIoT.Device.Platform.Interface.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Platform.Interface.1.0.26.3091\lib\MakoIoT.Device.Platform.Interface.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.FileStorage, Version=1.1.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\packages\MakoIoT.Device.Services.FileStorage.1.1.15.13530\lib\MakoIoT.Device.Services.FileStorage.dll</HintPath>
@@ -68,8 +68,8 @@
     <Reference Include="System.IO.Streams, Version=1.1.96.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.96\lib\System.IO.Streams.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net, Version=1.11.42.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Net.1.11.42\lib\System.Net.dll</HintPath>
+    <Reference Include="System.Net, Version=1.11.43.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Net.1.11.43\lib\System.Net.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http, Version=1.5.193.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.System.Net.Http.1.5.193\lib\System.Net.Http.dll</HintPath>

--- a/src/MakoIoT.Device.PlatformClient/packages.config
+++ b/src/MakoIoT.Device.PlatformClient/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MakoIoT.Device.Platform.Interface" version="1.0.25.43828" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Platform.Interface" version="1.0.26.3091" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.FileStorage" version="1.1.15.13530" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Interface" version="1.0.55.11594" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.17.11" targetFramework="netnano1.0" />
@@ -11,7 +11,7 @@
   <package id="nanoFramework.System.Collections" version="1.5.67" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.IO.FileSystem" version="1.1.85" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.IO.Streams" version="1.1.96" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net" version="1.11.42" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net" version="1.11.43" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Net.Http" version="1.5.193" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Runtime" version="1.0.28" />
   <package id="nanoFramework.System.Text" version="1.3.42" targetFramework="netnano1.0" />


### PR DESCRIPTION
Bumps MakoIoT.Device.Platform.Interface from 1.0.25.43828 to 1.0.26.3091</br>Bumps nanoFramework.System.Net from 1.11.42 to 1.11.43</br>
[version update]

### :warning: This is an automated update. :warning:
